### PR TITLE
Delete entries after submission

### DIFF
--- a/src/Actions/Login.php
+++ b/src/Actions/Login.php
@@ -16,6 +16,7 @@ class Login
 		if ( Utils::is_active() && ! empty( $form_id ) ) {
 			add_action( 'gform_validation_' . $form_id, [ __CLASS__, 'validation' ] );
 			add_filter( 'gform_confirmation_' . $form_id, [ 'Lean\Gforms\Utils', 'confirmation' ] );
+			add_filter( 'gform_after_submission_' . $form_id, [ 'Lean\Gforms\Utils', 'delete_entries' ] );
 		}
 	}
 

--- a/src/Actions/Signup.php
+++ b/src/Actions/Signup.php
@@ -16,6 +16,7 @@ class Signup
 		if ( Utils::is_active() && ! empty( $form_id ) ) {
 			add_action( 'gform_validation_' . $form_id, [ __CLASS__, 'validation' ] );
 			add_filter( 'gform_confirmation_' . $form_id, [ 'Lean\Gforms\Utils', 'confirmation' ] );
+			add_filter( 'gform_after_submission_' . $form_id, [ 'Lean\Gforms\Utils', 'delete_entries' ] );
 		}
 	}
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,4 +1,5 @@
 <?php namespace Lean\Gforms;
+use GFAPI;
 
 /**
  * Utils.
@@ -66,5 +67,16 @@ class Utils {
 		$confirmation .= '<!--cookies:' . wp_json_encode( self::get_cookies() ) . '-->';
 
 		return $confirmation;
+	}
+
+	/**
+	 * Delete the form entry after the form is submitted.
+	 * Usefull for Login/Signup forms, because we don't want
+	 * to store plain text passwords in the database as an entry.
+	 *
+	 * @param object $entry Gravity Forms entry.
+	 */
+	public static function delete_entries( $entry ) {
+		GFAPI::delete_entry( $entry['id'] );
 	}
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)

Security Bug Fix.
- **What is the current behavior?** (You can also link to an open issue
  here)

Information is stored as entries in all the forms.
- **What is the new behavior (if this is a feature change)?**

Prevent Login and Signup forms to store the information as an entry.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)

No.
- **Other information**:

Delete the entry after it's created. I think is the only way, because Gravity Forms has to store the information because of the internal hooks, notifications, etc...
