### PR TITLE
Trim the username so that it gets through the next if

### DIFF
--- a/src/Actions/Signup.php
+++ b/src/Actions/Signup.php
@@ -147,10 +147,11 @@ class Signup
 		if ( isset( $args['display_name'] ) ) {
 			$username = $args['display_name'];
 		} else {
-			$username =
+			$username = trim(
 				( isset( $args['first_name'] ) ? $args['first_name'] : '' ) .
 				' ' .
-				( isset( $args['last_name'] ) ? $args['last_name'] : '' );
+				( isset( $args['last_name'] ) ? $args['last_name'] : '' )
+			);
 		}
 
 		if ( ! $username ) {


### PR DESCRIPTION
If we only provide a `user_email` and a `user_pass` the generated username is empty.

This is because it ends up being a space ' ' and that doesnt get through the next if that works out a default value:

`if ( ! $username ) {`
